### PR TITLE
Updated MapChange signature to be compatible with 5.26

### DIFF
--- a/MenuVote.as
+++ b/MenuVote.as
@@ -106,7 +106,7 @@ void voteCleanup() {
 	}
 }
 
-HookReturnCode MapChange() {
+HookReturnCode MapChange(const string& in szNextMap) {
 	g_Scheduler.RemoveTimer(g_menuTimer);
 	return HOOK_CONTINUE;
 }

--- a/RockTheVote.as
+++ b/RockTheVote.as
@@ -151,7 +151,7 @@ void MapStart() {
 	DiffMapStart();
 }
 
-HookReturnCode MapChange() {
+HookReturnCode MapChange(const string& in szNextMap) {
 	writeActivePlayerStats();
 	g_player_activity.clear();
 	g_Scheduler.RemoveTimer(g_timer);


### PR DESCRIPTION
Problem:

RTV emits the error `ERROR: CModuleHookManager::RegisterHook: Function '::MapChange' is incompatible with hook 'MapChangeHook'!`

Fix:

Sven Coop 5.26 intentionally broke the MapChange hook to include a string of the next map: https://wiki.svencoop.com/Change_log/5.26#AngelScript

Just added the parameter and RTV seems to be working normally again.